### PR TITLE
external MPI found problems fixed

### DIFF
--- a/src/main/java/com/safecharge/model/ExternalMpi.java
+++ b/src/main/java/com/safecharge/model/ExternalMpi.java
@@ -5,19 +5,19 @@ import javax.validation.constraints.Size;
 
 public class ExternalMpi {
 
-    @Size(max = 1)
+    @Size(min=1, max = 1, message = "value is invalid. The allowed values are: (0, {max}).")
     @NotNull
     private String isExternalMpi;
 
-    @Size(max = 2)
+    @Size(min=1, max = 2, message = "value is invalid.")
     @NotNull
     String eci;
 
-    @Size(max = 50)
+    @Size(min=1, max = 50, message = "value is invalid. The length of the value should be between {min} and {max} symbols.")
     @NotNull
     String cavv;
 
-    @Size(max = 5)
+    @Size(max = 50, message = "value is invalid. The length of the value should be maximum {max} symbols.")
     String xid;
 
     public String getIsExternalMpi() {

--- a/src/main/java/com/safecharge/request/SafechargeCCRequest.java
+++ b/src/main/java/com/safecharge/request/SafechargeCCRequest.java
@@ -144,6 +144,10 @@ public abstract class SafechargeCCRequest extends SafechargeOrderDetailsRequest 
                 .append(cardData);
         sb.append(", userPaymentOption=")
                 .append(userPaymentOption);
+        sb.append(", isPartialApproval=")
+                .append(isPartialApproval);
+        sb.append(", externalMpi=")
+                .append(externalMpi);
         sb.append(", isRebilling=")
                 .append(isRebilling);
         sb.append(", ");


### PR DESCRIPTION
 - SafechargeCCRequest toString() method was missing external MPI block, and now is fixed.

 - the validations of externalMPI block were wrong but now are fixed.